### PR TITLE
Allow PlpProgram Creation With a Directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 }
 
 dependencies {
+    testImplementation("com.google.jimfs:jimfs:1.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
 }
@@ -48,7 +49,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.5
+                minimum = 0.9
             }
         }
 
@@ -59,7 +60,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'TOTALCOUNT'
-                maximum = 0.3
+                maximum = 0.9
             }
         }
     }

--- a/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
@@ -1,0 +1,78 @@
+package org.plp.implementations.plpisa;
+
+import org.plp.isa.AsmFile;
+import org.plp.isa.AsmProgram;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PlpProgram implements AsmProgram {
+
+    private final Map<String, AsmFile> filesInProgram;
+    private final Path programDirectory;
+
+    public PlpProgram(Path programDirectory) throws IOException{
+        filesInProgram = new HashMap<>();
+        this.programDirectory = programDirectory;
+        init();
+    }
+
+    private void init() throws IOException {
+        if(!Files.exists(programDirectory)) {
+            Files.createDirectories(programDirectory);
+        } else if(!Files.isDirectory(programDirectory)) {
+            throw new IOException("Path provided has a file instead of directory - " + programDirectory.toString());
+        }
+        // TODO: if the directory exists, read the asm files present in that directory.
+        // TODO: This will be implemented after PlpFile is implemented.
+    }
+
+    /**
+     * Provide the list of {@link AsmFile} which constitute this program
+     *
+     * @return list of {@link AsmFile}
+     */
+    @Override
+    public List<AsmFile> getAsmFilesOfProgram() {
+        return new ArrayList<>(filesInProgram.values());
+    }
+
+    /**
+     * Add the given {@link AsmFile} to this program
+     *
+     * @param asmFile AsmFile to be added to the program
+     * @return true if successfully able to add the file to program else false
+     */
+    @Override
+    public boolean addAsmFileToProgram(AsmFile asmFile) {
+        //ToBe Implemented
+        return false;
+    }
+
+    /**
+     * Creates a new {@link AsmFile} within in this program
+     *
+     * @param fileName Name of the {@link AsmFile} to be created
+     * @return {@link AsmFile} created in the program else null in case of failures
+     */
+    @Override
+    public AsmFile createAsmFileInProgram(String fileName) {
+        //ToBe Implemented
+        return null;
+    }
+
+    /**
+     * Provide the full path of the {@link AsmProgram} where it stores its files
+     *
+     * @return Absolute path of the program's direcotry.
+     */
+    @Override
+    public String getProgramDirectory() {
+        return programDirectory.toString();
+    }
+}

--- a/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
@@ -1,0 +1,96 @@
+package org.plp.implementations.plpisa;
+
+import org.plp.isa.AsmFile;
+import org.plp.isa.AsmProgram;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is the Plp representation of {@link AsmProgram}. This holds all the asm files a plp program will hold
+ * and also maps to a directory where it will store these files.
+ */
+public class PlpProgram implements AsmProgram {
+
+    private final Map<String, AsmFile> filesInProgram;
+    private final Path programDirectory;
+
+    public PlpProgram(Path programDirectory) throws IOException{
+        validatePath(programDirectory);
+        filesInProgram = new HashMap<>();
+        this.programDirectory = programDirectory;
+        loadFilesToMemory();
+    }
+
+    /**
+     * This verifies if given directory exists. If it does not, it will create one.
+     * @param programDirectory Directory Path which needs to be verified
+     * @throws IOException if program's path is invalid that is path is a file instead of directory
+     */
+    private void validatePath(Path programDirectory) throws IOException {
+        if(!Files.exists(programDirectory)) {
+            Files.createDirectories(programDirectory);
+        } else if(!Files.isDirectory(programDirectory)) {
+            throw new IOException("Path provided has a file instead of directory - " + programDirectory.toString());
+        }
+    }
+
+    /**
+     * This is read the content of the {@link #programDirectory} and if it has any {@link AsmFile}
+     * it will read it into memory.
+     * @throws IOException if it fails to read the {@link AsmFile}s
+     */
+    private void loadFilesToMemory() throws IOException {
+        // TODO: if the directory exists, read the asm files present in that directory.
+        // TODO: This will be implemented after PlpFile is implemented.
+    }
+
+    /**
+     * Provide the list of {@link AsmFile} which constitute this program
+     *
+     * @return list of {@link AsmFile}
+     */
+    @Override
+    public List<AsmFile> getAsmFilesOfProgram() {
+        return new ArrayList<>(filesInProgram.values());
+    }
+
+    /**
+     * Add the given {@link AsmFile} to this program
+     *
+     * @param asmFile AsmFile to be added to the program
+     * @return true if successfully able to add the file to program else false
+     */
+    @Override
+    public boolean addAsmFileToProgram(AsmFile asmFile) {
+        //ToBe Implemented
+        return false;
+    }
+
+    /**
+     * Creates a new {@link AsmFile} within in this program
+     *
+     * @param fileName Name of the {@link AsmFile} to be created
+     * @return {@link AsmFile} created in the program else null in case of failures
+     */
+    @Override
+    public AsmFile createAsmFileInProgram(String fileName) {
+        //ToBe Implemented
+        return null;
+    }
+
+    /**
+     * Provide the full path of the {@link AsmProgram} where it stores its files
+     *
+     * @return Absolute path of the program's direcotry.
+     */
+    @Override
+    public String getProgramDirectory() {
+        return programDirectory.toString();
+    }
+}

--- a/src/main/java/org/plp/isa/AsmProgram.java
+++ b/src/main/java/org/plp/isa/AsmProgram.java
@@ -13,9 +13,22 @@ public interface AsmProgram {
     List<AsmFile> getAsmFilesOfProgram();
 
     /**
-     * Add the given list of {@link AsmFile} to this program
-     * @param asmFiles list of AsmFiles to be added to the program
-     * @return true if successfully able to add the files to program else false
+     * Add the given {@link AsmFile} to this program
+     * @param asmFile AsmFile to be added to the program
+     * @return true if successfully able to add the file to program else false
      */
-    boolean addAsmFilesToProgram(List<AsmFile> asmFiles);
+    boolean addAsmFileToProgram(AsmFile asmFile);
+
+    /**
+     * Creates a new {@link AsmFile} within in this program
+     * @param fileName Name of the {@link AsmFile} to be created
+     * @return {@link AsmFile} created in the program else null in case of failures
+     */
+    AsmFile createAsmFileInProgram(String fileName);
+
+    /**
+     * Provide the full path of the {@link AsmProgram} where it stores its files
+     * @return Absolute path of the program's direcotry.
+     */
+    String getProgramDirectory();
 }

--- a/src/test/java/org/plp/implementations/plpisa/PlpProgramTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpProgramTest.java
@@ -1,0 +1,96 @@
+package org.plp.implementations.plpisa;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class PlpProgramTest {
+
+    FileSystem testOSXFileSystem;
+    FileSystem testUnixFileSystem;
+    FileSystem testWinFileSystem;
+
+    @BeforeEach
+    void initializeFileSystem() {
+        testOSXFileSystem = Jimfs.newFileSystem(Configuration.osX());
+        testUnixFileSystem = Jimfs.newFileSystem(Configuration.unix());
+        testWinFileSystem = Jimfs.newFileSystem(Configuration.windows());
+    }
+
+    @Test
+    void createPlpProgramSuccessFulTest() {
+        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
+        Assertions.assertFalse(Files.exists(programOSXDirectory));
+        Assertions.assertDoesNotThrow(() -> {
+            PlpProgram program = new PlpProgram(programOSXDirectory);
+        });
+        Assertions.assertTrue(Files.exists(programOSXDirectory));
+
+        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
+        Assertions.assertFalse(Files.exists(programUnixDirectory));
+        Assertions.assertDoesNotThrow(() -> new PlpProgram(programUnixDirectory));
+        Assertions.assertTrue(Files.exists(programUnixDirectory));
+
+        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
+        Assertions.assertFalse(Files.exists(programWinDirectory));
+        Assertions.assertDoesNotThrow(() -> new PlpProgram(programWinDirectory));
+        Assertions.assertTrue(Files.exists(programWinDirectory));
+
+    }
+
+    @Test
+    void createPlpProgramFailureFileExistsTest() throws IOException{
+        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
+        Files.createFile(programOSXDirectory);
+        Assertions.assertTrue(Files.exists(programOSXDirectory));
+        Assertions.assertThrows(IOException.class, () -> {
+            PlpProgram program = new PlpProgram(programOSXDirectory);
+        });
+        Assertions.assertFalse(Files.isDirectory(programOSXDirectory));
+
+        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
+        Files.createFile(programUnixDirectory);
+        Assertions.assertTrue(Files.exists(programUnixDirectory));
+        Assertions.assertThrows(IOException.class, () -> new PlpProgram(programUnixDirectory));
+        Assertions.assertFalse(Files.isDirectory(programUnixDirectory));
+
+        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
+        Files.createFile(programWinDirectory);
+        Assertions.assertTrue(Files.exists(programWinDirectory));
+        Assertions.assertThrows(IOException.class, () -> new PlpProgram(programWinDirectory));
+        Assertions.assertFalse(Files.isDirectory(programWinDirectory));
+
+    }
+
+    @Test
+    void getPlpProgramDirectoryTest() {
+        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
+        Assertions.assertDoesNotThrow(() -> {
+            PlpProgram program = new PlpProgram(programOSXDirectory);
+            Assertions.assertEquals(program.getProgramDirectory(), programOSXDirectory.toString());
+        });
+
+        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
+        Assertions.assertDoesNotThrow(() -> {
+            PlpProgram program = new PlpProgram(programUnixDirectory);
+            Assertions.assertEquals(program.getProgramDirectory(), programUnixDirectory.toString());
+        });
+
+        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
+        Assertions.assertDoesNotThrow(() -> {
+            PlpProgram program = new PlpProgram(programWinDirectory);
+            Assertions.assertEquals(program.getProgramDirectory(), programWinDirectory.toString());
+        });
+
+    }
+
+
+
+}


### PR DESCRIPTION
Any PlpProgram creation needs a directory inside which all the asm files will be present.
Still to do - if the directory already exists, read all the asm files present in that directory and create corresponding PlpFiles