### PR TITLE
Lexer implementation for PLP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,18 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.16'
     annotationProcessor 'org.projectlombok:lombok:1.18.16'
 
+    compile 'com.fasterxml.jackson.core:jackson-core:2.12.2'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.12.2'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.12.2'
+
     testCompileOnly 'org.projectlombok:lombok:1.18.16'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.16'
 
-    testImplementation("com.google.jimfs:jimfs:1.1")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
-    testImplementation("org.mockito:mockito-junit-jupiter:3.5.10")
-    testImplementation("org.hamcrest:hamcrest:2.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.5.10'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ repositories {
     mavenCentral()
 }
 
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
+
 dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.16'
     annotationProcessor 'org.projectlombok:lombok:1.18.16'

--- a/config/checkstyle/PLP_checkstyle.xml
+++ b/config/checkstyle/PLP_checkstyle.xml
@@ -20,7 +20,7 @@
    <!-- Checks for Line Length 									-->
    <!-- See https://checkstyle.sourceforge.io/config_sizes.html -->
     <module name="LineLength">
-		<property name="max" value="100"/>
+		<property name="max" value="120"/>
 	</module>
     <module name="TreeWalker">
 		<!-- Checks package naming -->

--- a/src/main/java/org/plp/implementations/plpisa/PlpLexer.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpLexer.java
@@ -1,0 +1,81 @@
+package org.plp.implementations.plpisa;
+
+import lombok.NonNull;
+import org.plp.isa.AsmLexer;
+import org.plp.isa.AsmToken;
+import org.plp.isa.exceptions.AsmIllegalTokenException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Given a line, this will provide a list of {@link PlpToken}
+ */
+public class PlpLexer implements AsmLexer {
+
+    /**
+     * Given a string it will provide a list of tokens consisting of the string
+     *
+     * @param input String which needs to be broken into individual tokens
+     * @return List of {@link AsmToken} consisting of that string
+     * @throws AsmIllegalTokenException when it cannot find the proper token type
+     */
+    @Override
+    public List<AsmToken> lex(@NonNull String input) throws AsmIllegalTokenException {
+
+        input = input.trim();
+
+        List<AsmToken> asmTokens = new ArrayList<>();
+
+        Pattern pattern = getCumulativeTokenPattern();
+        Matcher matcher = pattern.matcher(input);
+        Matcher nonSpaceMatcher = Pattern.compile("\\S").matcher(input);
+
+        int expectedTokenStartIndex = 0;
+
+        while(matcher.find(expectedTokenStartIndex)) {
+            if(expectedTokenStartIndex != matcher.start()) {
+                String errorMessage = String.format(
+                        "ERROR! Invalid Character Found: %s",
+                        input.substring(expectedTokenStartIndex));
+
+                throw new AsmIllegalTokenException(errorMessage);
+            }
+
+            for(PlpTokenType tokenType: PlpTokenType.values()) {
+                if(matcher.group(tokenType.name()) != null) {
+                    asmTokens.add(new PlpToken(tokenType, matcher.group(tokenType.name())));
+                    break;
+                }
+            }
+
+            expectedTokenStartIndex = matcher.end();
+            if(nonSpaceMatcher.find(expectedTokenStartIndex)) {
+                expectedTokenStartIndex = nonSpaceMatcher.start();
+            }
+        }
+
+        if(expectedTokenStartIndex < input.length()) {
+            String errorMessage = String.format(
+                    "ERROR! Invalid Character Found: %s",
+                    input.substring(expectedTokenStartIndex));
+
+            throw new AsmIllegalTokenException(errorMessage);
+
+        }
+
+        return asmTokens;
+    }
+
+    private Pattern getCumulativeTokenPattern() {
+        StringBuilder allPatterns = new StringBuilder();
+
+        for(PlpTokenType tokenType: PlpTokenType.values()) {
+            allPatterns.append(String.format("|(?<%s>%s)", tokenType.name(), tokenType.regex()));
+        }
+
+        return Pattern.compile(allPatterns.substring(1));
+    }
+}

--- a/src/main/java/org/plp/implementations/plpisa/PlpLexer.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpLexer.java
@@ -12,6 +12,8 @@ import java.util.regex.Pattern;
 
 /**
  * Given a line, this will provide a list of {@link PlpToken}
+ * Some of the ideas taken from
+ * http://giocc.com/writing-a-lexer-in-java-1-7-using-regex-named-capturing-groups.html
  */
 public class PlpLexer implements AsmLexer {
 

--- a/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
@@ -205,7 +205,7 @@ public class PlpProgram implements AsmProgram {
      */
     @Override
     public void loadProgram() throws IOException{
-        try(var zipFile = new ZipFile(this.programLocation.toString())) {
+        try(ZipFile zipFile = new ZipFile(this.programLocation.toString())) {
             ZipEntry metaDataEntry = zipFile.getEntry("metadata.json");
             this.plpProgramMetaData = objectMapper.readValue(zipFile.getInputStream(metaDataEntry),
                     PlpProgramMetaData.class);

--- a/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpProgram.java
@@ -1,19 +1,28 @@
 package org.plp.implementations.plpisa;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.plp.isa.AsmFile;
 import org.plp.isa.AsmProgram;
 
 import java.io.IOException;
+import java.io.InputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
 /**
  * This is a PLP representation of {@link AsmProgram}. This holds all the asm files a PLP
@@ -21,65 +30,47 @@ import java.util.stream.Stream;
  */
 public class PlpProgram implements AsmProgram {
 
-    private final Map<String, AsmFile> filesInProgram;
-    private final Path programDirectory;
+    private final Path programLocation;
+    private PlpProgramMetaData plpProgramMetaData;
+    private static final String EXTENSION_OF_PROGRAM = ".plp";
+    private static final String DEFAULT_MAIN_ASM_FILE = "main.asm";
+    private static final String META_DATA_FILE = "metadata.json";
+    private final Map<String, AsmFile> files;
+    private ObjectMapper objectMapper = null;
 
     /**
-     * Constructor for a PlpProgram object
-     *
-     * @param programDirectory - the directory where the asm file(s) are stored
-     * @throws IOException - thrown if the directory or files cannot be read
+     * Creates an {@link AsmProgram} for PLP
+     * @param programName Name of the Program to be created
+     * @param programLocation Location where the program needs to be created.
+     * @throws IOException Any error during creation or loading of existing program
      */
-    public PlpProgram(Path programDirectory) throws IOException{
-        validatePath(programDirectory);
-        filesInProgram = new HashMap<>();
-        this.programDirectory = programDirectory;
-        loadFilesToMemory();
-    }
+    public PlpProgram(String programName, Path programLocation) throws IOException{
+        this.objectMapper = new ObjectMapper();
+        files = new HashMap<>();
 
-    /**
-     * This verifies if given directory exists. If it does not, it will create one.
-     *
-     * @param programDirectory - directory path to be verified
-     * @throws IOException if the program path is invalid (i.e. it is a directory)
-     */
-    private void validatePath(Path programDirectory) throws IOException {
-        if(!Files.exists(programDirectory)) {
-            Files.createDirectories(programDirectory);
-        } else if(!Files.isDirectory(programDirectory)) {
-            throw new IOException("Path provided has a file instead of directory - "
-                    + programDirectory.toString());
+        String fileName = programName;
+        if(!programName.toLowerCase().endsWith(EXTENSION_OF_PROGRAM)) {
+            fileName += EXTENSION_OF_PROGRAM;
+        }
+
+        this.programLocation = Paths.get(programLocation.toString(), fileName);
+
+        if(Files.exists(this.programLocation)) {
+            loadProgram();
+        } else {
+            this.plpProgramMetaData = new PlpProgramMetaData(programName);
+            createAsmFileInProgram(DEFAULT_MAIN_ASM_FILE);
         }
     }
 
     /**
-     * Reads the content of the {@link #programDirectory} and if it has any {@link AsmFile}s
-     * it will read them into memory.
-     * @throws IOException if it fails to read the {@link AsmFile}s
-     * @throws UnsupportedOperationException - thrown until implemented
-     */
-    private void loadFilesToMemory() throws IOException {
-        if(Files.exists(programDirectory)) {
-            try (Stream<Path> paths = Files.walk(programDirectory)) {
-                List<Path> programFiles = paths.filter(Files::isRegularFile)
-                        .collect(Collectors.toList());
-                for(Path path: programFiles) {
-                    AsmFile asmFile = new PlpFile(path);
-                    filesInProgram.put(asmFile.getFileName(), asmFile);
-                }
-
-            }
-        }
-    }
-
-    /**
-     * Returns a list of {@link AsmFile}s which constitute this program
+     * Provide the list of {@link AsmFile} which constitute this program
      *
-     * @return - list of {@link AsmFile}
+     * @return list of {@link AsmFile}
      */
     @Override
     public List<AsmFile> getAsmFilesOfProgram() {
-        return new ArrayList<>(filesInProgram.values());
+        return this.files.values().stream().collect(Collectors.toUnmodifiableList());
     }
 
     /**
@@ -87,38 +78,11 @@ public class PlpProgram implements AsmProgram {
      *
      * @param fileName - name of the given {@link AsmFile}
      * @return - null if there is no {@link AsmFile} with the corresponding name,
-     *           otherwise the {@link AsmFile} with the given name
+     * otherwise the {@link AsmFile} with the given name
      */
     @Override
     public AsmFile getAsmFile(String fileName) {
-        return filesInProgram.get(fileName);
-    }
-
-    /**
-     * Copy the given {@link AsmFile} to this program. It is going to copy the content to the passed
-     * {@link AsmFile} as {@link AsmFile} path is immutable.
-     * @param asmFile AsmFile to be added to the program
-     * @return returns the new {@link AsmFile} created from the content of passed {@link AsmFile}
-     * @throws IOException if already a {@link AsmFile} with same name exists in program
-     */
-    @Override
-    public AsmFile copyAsmFileToProgram(AsmFile asmFile) throws IOException{
-        AsmFile newFile = null;
-        if(!filesInProgram.containsKey(asmFile.getFileName())) {
-
-            Path newFilePath = Paths.get(programDirectory.toString(), asmFile.getFileName());
-            Files.copy(asmFile.getFilePath(),
-                    newFilePath,
-                    StandardCopyOption.REPLACE_EXISTING);
-
-            newFile = new PlpFile(newFilePath);
-            filesInProgram.put(newFile.getFileName(), newFile);
-        } else {
-            throw new IOException(String.format("File with same name %s exists in the program %s",
-                    asmFile.getFileName(),
-                    programDirectory.getFileName()));
-        }
-        return newFile;
+        return this.files.get(fileName);
     }
 
     /**
@@ -129,26 +93,168 @@ public class PlpProgram implements AsmProgram {
      * @throws IOException {@link AsmFile} file with same name already exists
      */
     @Override
-    public AsmFile createAsmFileInProgram(String fileName) throws IOException{
-        AsmFile plpFile = null;
-        if(filesInProgram.containsKey(fileName)) {
-            throw new IOException(String.format("File with same name %s exists in the program %s",
-                    fileName,
-                    programDirectory.getFileName()));
-        } else {
-            plpFile = new PlpFile(Paths.get(programDirectory.toString(), fileName));
-            filesInProgram.put(plpFile.getFileName(), plpFile);
+    public AsmFile createAsmFileInProgram(String fileName) throws IOException {
+        if(!this.files.containsKey(fileName)) {
+            AsmFile asmFile = new PlpFile(fileName, this);
+            addFileToProgram(asmFile);
+            saveProgram();
+            return asmFile;
         }
-        return plpFile;
+
+        throw new IOException(
+                String.format("%s program already has a file with the same name as %s",
+                        this.getProgramName(),
+                        fileName));
+
     }
 
     /**
-     * Provides the full path of the {@link AsmProgram} where the files are stored
+     * Deletes an {@link AsmFile} with name fileName present in the Program
      *
-     * @return - absolute path of the program's directory.
+     * @param fileName {@link AsmFile} name which needs to be deleted
+     * @throws IOException {@link AsmFile} file with name does not exists or fails to delete
      */
     @Override
-    public String getProgramDirectory() {
-        return programDirectory.toString();
+    public void deleteAsmFileInProgram(String fileName) throws IOException {
+        if(this.files.containsKey(fileName)) {
+            deleteFileFromProgram(this.files.get(fileName));
+            saveProgram();
+        } else {
+            throw new IOException(
+                    String.format("%s program do not have file %s",
+                            this.getProgramName(),
+                            fileName));
+        }
+    }
+
+    /**
+     * This helps to rename an existing {@link AsmFile} in the program to new {@link AsmFile} file
+     *
+     * @param currentName Existing name of the {@link AsmFile}
+     * @param newName     New Name of the {@link AsmFile}
+     * @throws IOException {@link AsmFile} file with same new name already exists
+     */
+    @Override
+    public void renameAsmFileInProgram(String currentName, String newName) throws IOException {
+        if(this.files.containsKey(currentName) && !this.files.containsKey(newName)) {
+            AsmFile oldFile = this.files.get(currentName);
+            AsmFile newFile = new PlpFile(newName, this);
+            newFile.appendInstructionsToFile(oldFile.getInstructionsOfFile());
+            int index = this.plpProgramMetaData.getProgramFiles().indexOf(currentName);
+            deleteAsmFileInProgram(currentName);
+            addFileToProgramAtIndex(newFile, index);
+            saveProgram();
+
+        } else if(!this.files.containsKey(currentName)) {
+            throw new IOException(
+                    String.format("%s program does not have file %s", this.getProgramName(), currentName)
+            );
+
+        } else {
+            throw new IOException(
+                    String.format("%s program already has a file with same name - %s", this.getProgramName(), newName)
+            );
+        }
+    }
+
+    /**
+     * Get the program name
+     *
+     * @return name of the program
+     */
+    @Override
+    public String getProgramName() {
+        return programLocation.getFileName().toString();
+    }
+
+    /**
+     * Full path of the Program
+     *
+     * @return File location where the program is saved
+     */
+    @Override
+    public Path getProgramLocation() {
+        return programLocation;
+    }
+
+    /**
+     * This will save the program in the disk
+     * @throws IOException Any error during writing to disk
+     */
+    @Override
+    public void saveProgram() throws IOException {
+        try(ZipOutputStream zipOutputStream = new ZipOutputStream(
+                new BufferedOutputStream(Files.newOutputStream(this.programLocation)))) {
+            String metaDataContent = getMetaDataFileContent();
+            zipOutputStream.putNextEntry(new ZipEntry(META_DATA_FILE));
+            zipOutputStream.write(metaDataContent.getBytes(StandardCharsets.UTF_8));
+            zipOutputStream.closeEntry();
+
+            for(String asmFileName: this.plpProgramMetaData.getProgramFiles()) {
+                zipOutputStream.putNextEntry(new ZipEntry(asmFileName));
+                String fileContent = getAsmFileContentAsString(this.files.get(asmFileName));
+                zipOutputStream.write(fileContent.getBytes(StandardCharsets.UTF_8));
+                zipOutputStream.closeEntry();
+            }
+        }
+    }
+
+    /**
+     * This will read the file from the disk to memory
+     * @throws IOException Any error during the file reading
+     */
+    @Override
+    public void loadProgram() throws IOException{
+        try(var zipFile = new ZipFile(this.programLocation.toString())) {
+            ZipEntry metaDataEntry = zipFile.getEntry("metadata.json");
+            this.plpProgramMetaData = objectMapper.readValue(zipFile.getInputStream(metaDataEntry),
+                    PlpProgramMetaData.class);
+            for(String fileName: this.plpProgramMetaData.getProgramFiles()) {
+                ZipEntry fileEntry = zipFile.getEntry(fileName);
+                List<String> content = getContentOfFile(zipFile.getInputStream(fileEntry));
+                PlpFile plpFile = new PlpFile(fileName, this, content);
+                this.files.put(fileName, plpFile);
+            }
+        }
+
+    }
+
+    private void addFileToProgram(AsmFile asmFile) {
+        this.files.put(asmFile.getFileName(), asmFile);
+        this.plpProgramMetaData.addFileToProgram(asmFile.getFileName());
+    }
+
+    private void addFileToProgramAtIndex(AsmFile asmFile, int index) {
+        this.files.put(asmFile.getFileName(), asmFile);
+        this.plpProgramMetaData.addFileToProgramAtIndex(asmFile.getFileName(), index);
+    }
+
+    private void deleteFileFromProgram(AsmFile asmFile) {
+        this.files.remove(asmFile.getFileName(), asmFile);
+        this.plpProgramMetaData.deleteFileInProgram(asmFile.getFileName());
+    }
+
+    private String getMetaDataFileContent() throws JsonProcessingException {
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this.plpProgramMetaData);
+    }
+
+    private String getAsmFileContentAsString(AsmFile asmFile) {
+        List<String> instructions = asmFile.getInstructionsOfFile();
+        if(instructions.size() == 0) {
+            return "";
+        }
+        return String.join(System.lineSeparator(), instructions);
+    }
+
+    private List<String> getContentOfFile(InputStream inputStream) throws IOException{
+        List<String> fileContent = new ArrayList<>();
+        try(BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line = "";
+            while((line = reader.readLine()) != null) {
+                fileContent.add(line);
+            }
+        }
+
+        return fileContent;
     }
 }

--- a/src/main/java/org/plp/implementations/plpisa/PlpProgramMetaData.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpProgramMetaData.java
@@ -1,0 +1,92 @@
+package org.plp.implementations.plpisa;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This will hold the meta data needed for the {@link PlpProgram}
+ */
+public class PlpProgramMetaData {
+    private final String version = "7.0";
+    private final String programName;
+    private final List<String> programFiles;
+
+    /**
+     * This will create a metadata for the {@link PlpProgram}
+     * @param programName Name of the program
+     */
+    public PlpProgramMetaData(String programName) {
+        this.programName = programName;
+        programFiles = new ArrayList<>();
+    }
+
+    /**
+     * This will create a metadata for the {@link PlpProgram}
+     * @param programName Name of the program
+     * @param programFiles list of files present in the {@link PlpProgram}
+     */
+    @JsonCreator
+    public PlpProgramMetaData(@JsonProperty("programName") String programName,
+                              @JsonProperty("programFiles") List<String> programFiles) {
+        this.programName = programName;
+        this.programFiles = new ArrayList<>(programFiles);
+    }
+
+    /**
+     * Get the Name of the {@link PlpProgram}
+     * @return name of the program
+     */
+    public String getProgramName() {
+        return this.programName;
+    }
+
+    /**
+     * Get the Version of {@link PlpProgram}
+     * @return current version of PLP
+     */
+    public String getVersion() {
+        return this.version;
+    }
+
+    /**
+     * This will add the name of {@link PlpFile} added to {@link PlpProgram}
+     * @param fileName name of {@link PlpFile}
+     */
+    public void addFileToProgram(String fileName) {
+        programFiles.add(fileName);
+    }
+
+    /**
+     * This will add the name of {@link PlpFile} added to {@link PlpProgram} at a particular order
+     * @param fileName name of {@link PlpFile}
+     * @param index position of the file to be added
+     */
+    public void addFileToProgramAtIndex(String fileName, int index) {
+        if(index >= programFiles.size()) {
+            addFileToProgram(fileName);
+        } else {
+            programFiles.add(index, fileName);
+        }
+    }
+
+    /**
+     * Delete the {@link PlpFile} from the {@link PlpProgram}
+     * @param fileName name of the {@link PlpFile} to be deleted
+     */
+    public void deleteFileInProgram(String fileName) {
+        programFiles.remove(fileName);
+    }
+
+    /**
+     * Get the list of {@link PlpFile}'s present in the {@link PlpProgram}
+     * @return list of PlpFile
+     */
+    public List<String> getProgramFiles() {
+        return Collections.unmodifiableList(programFiles);
+    }
+
+}

--- a/src/main/java/org/plp/implementations/plpisa/PlpToken.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpToken.java
@@ -1,0 +1,48 @@
+package org.plp.implementations.plpisa;
+
+import lombok.NonNull;
+import org.plp.isa.AsmToken;
+import org.plp.isa.AsmTokenType;
+
+/**
+ * This represents the each tokens which will be created by the Lexer or Tokenizer
+ * Example, In assembler directive `.org 0x100000`,
+ * here .org is a token and 0x100000 is also another token.
+ */
+public class PlpToken implements AsmToken {
+
+    PlpTokenType plpTokenType;
+    String actualValue;
+
+    /**
+     * Create a plptoken based on tokentype and the actual value
+     *
+     * @param plpTokenType {@link PlpTokenType} token type of actual value
+     * @param actualValue value whose token representation is stored
+     */
+    public PlpToken(@NonNull PlpTokenType plpTokenType, @NonNull String actualValue) {
+        this.plpTokenType = plpTokenType;
+        this.actualValue = actualValue;
+    }
+
+    /**
+     * This will return the token type of the value stored.
+     * if value is .org then token type would be DIRECTIVE
+     *
+     * @return {@link AsmTokenType} Token type of value.
+     */
+    @Override
+    public AsmTokenType getTokenType() {
+        return plpTokenType;
+    }
+
+    /**
+     * This will return the actual value of the Token stored
+     *
+     * @return actual value stored as string
+     */
+    @Override
+    public String getValue() {
+        return actualValue;
+    }
+}

--- a/src/main/java/org/plp/implementations/plpisa/PlpTokenType.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpTokenType.java
@@ -11,7 +11,7 @@ public enum PlpTokenType implements AsmTokenType {
      * This token identifies all the label definitions
      * Example  main:
      */
-    LABEL_DEFINITION("\\b[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]:\\B"),
+    LABELDEFINITION("\\b[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]:\\B"),
 
     /**
      *  This tells what can be a possible instruction token, whether this instruction
@@ -19,21 +19,30 @@ public enum PlpTokenType implements AsmTokenType {
      *  So this will include pseudo instruction as well as actual instructions
      *  Example addu
      */
-    INSTRUCTION("\\b[a-zA-Z]+\\b"),
+    INSTRUCTION("(?i)\\b(addu|addiu|subu|mullo|mulhi|lui|and|andi|or|ori|" +
+            "nor|slt|slti|sltu|sltiu|sll|sllv|srl|srlv|beq|bne|j|jal|jr|jalr|" +
+            "lw|sw)\\b"),
+
+    /**
+     * This tells what are the possible peudo instruction tokens.
+     * Example nop, b, move
+     */
+    PSEUDOINSTRUCTION("(?i)\\b(nop|b|move|push|pop|li|call|return|save|restore|" +
+            "lwm|swm)\\b"),
 
     /**
      * This token represents whenever label is used inside the instruction
      * example branch destination
      * Example MAIN
      */
-    LABEL_USAGE("\\b[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]\\b"),
+    LABELUSAGE("\\b[a-zA-Z][a-zA-Z0-9_]*[a-zA-Z0-9]\\b"),
 
     /**
      * Possible register patterns, this can pick some registers which is not
      * defined at in the Plp yet
      * Example $t1 $0
      */
-    REGISTER("\\$(0|([a-zA-Z]+)|([a-zA-Z][a-zA-Z0-9]+))"),
+     REGISTER("\\$([a-zA-Z]|[0-9])+"),
 
     /**
      * This represents the comments of Plp program
@@ -51,7 +60,7 @@ public enum PlpTokenType implements AsmTokenType {
      * For instructions like load and store words we use register with a number
      * Example lw $t0, 8($t1)
      */
-    PARENTHESIS_REGISTER("\\(\\$(0|([a-zA-Z]+)|([a-zA-Z][a-zA-Z0-9]+))\\)"),
+    PARENTHESISREGISTER("\\(\\$([a-zA-Z]|[0-9])+\\)"),
 
     /**
      * This represents any assembler directives
@@ -81,7 +90,8 @@ public enum PlpTokenType implements AsmTokenType {
      * This will identify any of the newline, empty lines,  tab representation
      * Example \n
      */
-    NEW_LINE("^\\s*$");
+    NEWLINE("^\\s*$");
+
 
     private final String regex;
 

--- a/src/main/java/org/plp/implementations/plpisa/PlpTokenType.java
+++ b/src/main/java/org/plp/implementations/plpisa/PlpTokenType.java
@@ -84,13 +84,7 @@ public enum PlpTokenType implements AsmTokenType {
      * We can have decimal, hexadecimal and binary number representation
      * Example 34543 -45 0xFEED 0b010101
      */
-    NUMERIC("((-?[1-9]\\d*)|0+|0x([0-9a-fA-F]+)|0b([01]+))\\b"),
-
-    /**
-     * This will identify any of the newline, empty lines,  tab representation
-     * Example \n
-     */
-    NEWLINE("^\\s*$");
+    NUMERIC("((-?[1-9]\\d*)|0+|0x([0-9a-fA-F]+)|0b([01]+))\\b");
 
 
     private final String regex;

--- a/src/main/java/org/plp/isa/AsmFile.java
+++ b/src/main/java/org/plp/isa/AsmFile.java
@@ -1,63 +1,58 @@
 package org.plp.isa;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 
 /**
  * This is the assembly program representation. It also handles the disk I/O of the program.
  */
 public interface AsmFile {
-    /**
-     * This will write the in-memory instructions of the program represented as
-     * {@link #getInstructions()} to disk at the path given by {@link #getFilePath()}
-     *
-     * @return - true if writing to the file was successful, false otherwise
-     * @throws IOException any file write related IO Exception
-     */
-    boolean writeToFile() throws IOException;
 
     /**
-     * This will provide the disk file path where the AsmFile will be written to
-     * by {@link #writeToFile()} and similarly from where this will read the file
-     * in {@link #readFromFile()}
-     * @return Path of the file
+     * This will add the list of instructions at the end of file
+     * @param instructions list of instructions to be added
+     * @throws IOException if it fails to update the physical file
      */
-    Path getFilePath();
+    void appendInstructionsToFile(List<String> instructions) throws IOException;
 
     /**
-     * Given an instruction of the program, this will add it to its in-memory representation
-     * of that program
-     *
-     * @param instruction - Instruction to be added to its in-memory representation
-     * @return - true if instruction is successfully added, false otherwise
+     * This will add list of instructions from the lineNumber specified. \
+     * If there are fewer lines in the file, then it will add lines at the end.
+     * @param lineNumber Line number where the instructions need to be added
+     * @param instructions list of instructions to be added to file.
+     * @throws IOException if it fails to update the physical file
      */
-    boolean addInstructionToFile(String instruction);
+    void addInstructionsAtLine(int lineNumber, List<String> instructions) throws IOException;
+
+    /**
+     * This will remove an instruction from the file at the given line number
+     * @param lineNumber line number at which instruction needs to be removed.
+     * @throws IOException if it fails to update the physical file
+     */
+    void removeInstructionAtLine(int lineNumber) throws IOException;
+
+    /**
+     * This will remove all the instructions present in the file
+     * @throws IOException if it fails to update the physical file
+     */
+    void clearInstructions() throws IOException;
 
     /**
      * Given a lineNumber, obtain the instruction present at that line
      *
      * @param lineNumber - line number in the file/program
      * @return - instruction present at that line
+     * @throws IOException if there are no instructions at that line number
      */
-    String getInstructionAtLine(int lineNumber);
+    String getInstructionAtLine(int lineNumber) throws IOException;
 
     /**
      * Get all the instructions stored in memory of this file.
      *
-     * Use this only after {@link #readFromFile()} or {@link #addInstructionToFile(String)}
-     *
      * @return - list of instructions present in the file.
      */
-    List<String> getInstructions();
+    List<String> getInstructionsOfFile();
 
-    /**
-     * This will read the contents of the file present at {@link #getFilePath()} and store
-     * all the instructions contained in the file in memory.
-     *
-     * @throws IOException - thrown if file cannot be read
-     */
-    void readFromFile() throws IOException;
 
     /**
      * Name of the file in which this file will be stored within in the {@link AsmProgram}
@@ -66,4 +61,9 @@ public interface AsmFile {
      */
     String getFileName();
 
+    /**
+     * The {@link AsmProgram} to which this {@link AsmFile} belongs to
+     * @return {@link AsmProgram} of the {@link AsmFile}
+     */
+    AsmProgram getAsmProgramOfFile();
 }

--- a/src/main/java/org/plp/isa/AsmLexer.java
+++ b/src/main/java/org/plp/isa/AsmLexer.java
@@ -1,2 +1,17 @@
-package org.plp.isa;public class AsmLexer {
+package org.plp.isa;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+/**
+ * Given a string it will provide the list of tokens present in that string
+ */
+public interface AsmLexer {
+    /**
+     * Given a string it will provide a list of tokens consisting of the string
+     * @param input String which needs to be broken into individual tokens
+     * @return List of {@link AsmToken} consisting of that string
+     */
+    List<AsmToken> lex(@NonNull String input);
 }

--- a/src/main/java/org/plp/isa/AsmLexer.java
+++ b/src/main/java/org/plp/isa/AsmLexer.java
@@ -1,0 +1,2 @@
+package org.plp.isa;public class AsmLexer {
+}

--- a/src/main/java/org/plp/isa/AsmLexer.java
+++ b/src/main/java/org/plp/isa/AsmLexer.java
@@ -1,6 +1,7 @@
 package org.plp.isa;
 
 import lombok.NonNull;
+import org.plp.isa.exceptions.AsmIllegalTokenException;
 
 import java.util.List;
 
@@ -12,6 +13,7 @@ public interface AsmLexer {
      * Given a string it will provide a list of tokens consisting of the string
      * @param input String which needs to be broken into individual tokens
      * @return List of {@link AsmToken} consisting of that string
+     * @throws AsmIllegalTokenException when it cannot find the proper token type
      */
-    List<AsmToken> lex(@NonNull String input);
+    List<AsmToken> lex(@NonNull String input) throws AsmIllegalTokenException;
 }

--- a/src/main/java/org/plp/isa/AsmProgram.java
+++ b/src/main/java/org/plp/isa/AsmProgram.java
@@ -1,12 +1,14 @@
 package org.plp.isa;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
  * An Assembly program can be distributed across multiple asm files.
  */
 public interface AsmProgram {
+
     /**
      * Provide the list of {@link AsmFile} which constitute this program
      * @return list of {@link AsmFile}
@@ -23,15 +25,6 @@ public interface AsmProgram {
     AsmFile getAsmFile(String fileName);
 
     /**
-     * Copy the given {@link AsmFile} to this program. It is going to copy the content to the passed
-     * {@link AsmFile} as {@link AsmFile} path is immutable.
-     * @param asmFile AsmFile to be added to the program
-     * @return returns the new {@link AsmFile} created from the content of passed {@link AsmFile}
-     * @throws IOException if already a {@link AsmFile} with same name exists in program
-     */
-    AsmFile copyAsmFileToProgram(AsmFile asmFile) throws IOException;
-
-    /**
      * Creates a new {@link AsmFile} within in this program
      *
      * @param fileName - name of the {@link AsmFile} to be created
@@ -41,9 +34,44 @@ public interface AsmProgram {
     AsmFile createAsmFileInProgram(String fileName) throws IOException;
 
     /**
-     * Provides the full path of the {@link AsmProgram} where the files are stored
+     * Deletes an {@link AsmFile} with name fileName present in the Program
      *
-     * @return - absolute path of the program's directory.
+     * @param fileName {@link AsmFile} name which needs to be deleted
+     * @throws IOException {@link AsmFile} file with name does not exists or fails to delete
      */
-    String getProgramDirectory();
+    void deleteAsmFileInProgram(String fileName) throws IOException;
+
+    /**
+     * This helps to rename an existing {@link AsmFile} in the program to new {@link AsmFile} file
+     *
+     * @param currentName Existing name of the {@link AsmFile}
+     * @param newName New Name of the {@link AsmFile}
+     * @throws IOException {@link AsmFile} file with same new name already exists
+     */
+    void renameAsmFileInProgram(String currentName, String newName) throws IOException;
+
+    /**
+     * Get the program name
+     *
+     * @return name of the program
+     */
+    String getProgramName();
+
+    /**
+     * Full path of the Program
+     * @return File location where the program is saved
+     */
+    Path getProgramLocation();
+
+    /**
+     * This will save the program in the disk
+     * @throws IOException Any error during writing to disk
+     */
+    void saveProgram() throws IOException;
+
+    /**
+     * This will read the file from the disk to memory
+     * @throws IOException Any error during the file reading
+     */
+    void loadProgram() throws IOException;
 }

--- a/src/main/java/org/plp/isa/AsmToken.java
+++ b/src/main/java/org/plp/isa/AsmToken.java
@@ -1,0 +1,21 @@
+package org.plp.isa;
+
+/**
+ * Given a line, Tokenizer/Lexer will generate a list of tokens
+ * Example: Given `.org 0x100000` as input to Lexer, it will
+ * generate two tokens DIRECTIVE(.org) and NUMERIC(0x100000)
+ */
+public interface AsmToken {
+    /**
+     * This will return the token type of the value stored.
+     * if value is .org then token type would be DIRECTIVE
+     * @return {@link AsmTokenType} Token type of value.
+     */
+    AsmTokenType getTokenType();
+
+    /**
+     * This will return the actual value of the Token stored
+     * @return actual value stored as string
+     */
+    String getValue();
+}

--- a/src/main/java/org/plp/isa/exceptions/AsmIllegalTokenException.java
+++ b/src/main/java/org/plp/isa/exceptions/AsmIllegalTokenException.java
@@ -1,0 +1,15 @@
+package org.plp.isa.exceptions;
+
+/**
+ * This exception is thrown when it finds input string or token that cannot be classified
+ */
+public class AsmIllegalTokenException extends AsmAssemblerException {
+    /**
+     * Constructor of the exception
+     *
+     * @param message this is the reason for the error
+     */
+    public AsmIllegalTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/org/plp/implementations/plpisa/PlpLexerTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpLexerTest.java
@@ -196,7 +196,7 @@ public class PlpLexerTest {
     }
 
     @Test
-    public void testInvlaidTokenAtTheEndLex() {
+    public void testInvalidTokenAtTheEndLex() {
         String input = "b testbranch(";
 
         PlpLexer lexer = new PlpLexer();

--- a/src/test/java/org/plp/implementations/plpisa/PlpLexerTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpLexerTest.java
@@ -1,0 +1,209 @@
+package org.plp.implementations.plpisa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.plp.isa.AsmToken;
+import org.plp.isa.exceptions.AsmIllegalTokenException;
+
+import java.util.List;
+
+public class PlpLexerTest {
+
+    @Test
+    public void testSuccessFullParsing() {
+        String input = ".org 0x100000";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(2, tokens.size());
+        Assertions.assertEquals(PlpTokenType.DIRECTIVE.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals(".org", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.NUMERIC.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("0x100000", tokens.get(1).getValue());
+    }
+
+    @Test
+    public void testCommentParsing() {
+        String input = "# This is just a comment; .org 0x10000 addu $t0, $a1";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(1, tokens.size());
+        Assertions.assertEquals(PlpTokenType.COMMENT.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals(input, tokens.get(0).getValue());
+    };
+
+    @Test
+    public void testInstructionParsing() {
+        String input = "addu $v0, $a0, $a1";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(6, tokens.size());
+        Assertions.assertEquals(PlpTokenType.INSTRUCTION.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals("addu", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("$v0", tokens.get(1).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(2).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(2).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(3).getTokenType().toString());
+        Assertions.assertEquals("$a0", tokens.get(3).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(4).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(4).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(5).getTokenType().toString());
+        Assertions.assertEquals("$a1", tokens.get(5).getValue());
+    }
+
+    @Test
+    public void testInstructionWithParameterRegister() {
+        String input = "lw $t0, 8($t1)";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(5, tokens.size());
+        Assertions.assertEquals(PlpTokenType.INSTRUCTION.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals("lw", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("$t0", tokens.get(1).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(2).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(2).getValue());
+        Assertions.assertEquals(PlpTokenType.NUMERIC.name(), tokens.get(3).getTokenType().toString());
+        Assertions.assertEquals("8", tokens.get(3).getValue());
+        Assertions.assertEquals(PlpTokenType.PARENTHESISREGISTER.name(), tokens.get(4).getTokenType().toString());
+        Assertions.assertEquals("($t1)", tokens.get(4).getValue());
+
+    }
+
+    @Test
+    public void testLabelDeclarationParsing() {
+        String input = "test_label: #This is a label test";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(2, tokens.size());
+        Assertions.assertEquals(PlpTokenType.LABELDEFINITION.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals("test_label:", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMENT.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("#This is a label test", tokens.get(1).getValue());
+    }
+
+    @Test
+    public void testLexingOfLabelUsage() {
+        String input = "beq $a0, $a1, done";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(6, tokens.size());
+        Assertions.assertEquals(PlpTokenType.INSTRUCTION.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals("beq", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("$a0", tokens.get(1).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(2).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(2).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(3).getTokenType().toString());
+        Assertions.assertEquals("$a1", tokens.get(3).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(4).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(4).getValue());
+        Assertions.assertEquals(PlpTokenType.LABELUSAGE.name(), tokens.get(5).getTokenType().toString());
+        Assertions.assertEquals("done", tokens.get(5).getValue());
+
+    }
+
+    @Test
+    public void testStringLexToken() {
+        String input = ".ascii \"example string\"";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(2, tokens.size());
+        Assertions.assertEquals(PlpTokenType.DIRECTIVE.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals(".ascii", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.STRING.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("\"example string\"", tokens.get(1).getValue());
+
+    }
+
+    @Test
+    public void testCharacterToken() {
+        String input = "ADDIU $V0, $A0, 'A'";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(6, tokens.size());
+        Assertions.assertEquals(PlpTokenType.INSTRUCTION.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals("ADDIU", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("$V0", tokens.get(1).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(2).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(2).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(3).getTokenType().toString());
+        Assertions.assertEquals("$A0", tokens.get(3).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(4).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(4).getValue());
+        Assertions.assertEquals(PlpTokenType.CHARACTER.name(), tokens.get(5).getTokenType().toString());
+        Assertions.assertEquals("'A'", tokens.get(5).getValue());
+
+    }
+
+    @Test
+    public void testPseudoInstructionLex() {
+        String input = "li $v0, error";
+
+        PlpLexer lexer = new PlpLexer();
+        List<AsmToken> tokens = lexer.lex(input);
+
+        Assertions.assertEquals(4, tokens.size());
+        Assertions.assertEquals(PlpTokenType.PSEUDOINSTRUCTION.name(), tokens.get(0).getTokenType().toString());
+        Assertions.assertEquals("li", tokens.get(0).getValue());
+        Assertions.assertEquals(PlpTokenType.REGISTER.name(), tokens.get(1).getTokenType().toString());
+        Assertions.assertEquals("$v0", tokens.get(1).getValue());
+        Assertions.assertEquals(PlpTokenType.COMMA.name(), tokens.get(2).getTokenType().toString());
+        Assertions.assertEquals(",", tokens.get(2).getValue());
+        Assertions.assertEquals(PlpTokenType.LABELUSAGE.name(), tokens.get(3).getTokenType().toString());
+        Assertions.assertEquals("error", tokens.get(3).getValue());
+    }
+
+    @Test
+    public void testInvlaidTokenLex() {
+        String input = "*234 $v0";
+
+        PlpLexer lexer = new PlpLexer();
+
+        Assertions.assertThrows(AsmIllegalTokenException.class,
+                () -> lexer.lex(input),
+                "ERROR! Invalid Character Found: *234 $v0");
+
+    }
+
+    @Test
+    public void testInvlaidTokenInTheMiddleLex() {
+        String input = "li 23@4 mylabel";
+
+        PlpLexer lexer = new PlpLexer();
+
+        Assertions.assertThrows(AsmIllegalTokenException.class,
+                () -> lexer.lex(input),
+                "ERROR! Invalid Character Found: 23@4 mylabel");
+
+    }
+
+    @Test
+    public void testInvlaidTokenAtTheEndLex() {
+        String input = "b testbranch(";
+
+        PlpLexer lexer = new PlpLexer();
+
+        Assertions.assertThrows(AsmIllegalTokenException.class,
+                () -> lexer.lex(input),
+                "ERROR! Invalid Character Found: (");
+
+    }
+}

--- a/src/test/java/org/plp/implementations/plpisa/PlpProgramMetaDataTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpProgramMetaDataTest.java
@@ -1,0 +1,78 @@
+package org.plp.implementations.plpisa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PlpProgramMetaDataTest {
+
+    PlpProgramMetaData metaData;
+
+    @BeforeEach
+    public void setup() {
+        metaData = new PlpProgramMetaData("testProgram");
+    }
+
+    @Test
+    public void testPlpProgramMetaDataCreation() {
+        Assertions.assertEquals("testProgram", metaData.getProgramName());
+        Assertions.assertEquals("7.0", metaData.getVersion());
+    }
+
+    @Test
+    public void testPlpProgramMetaDataFiles() {
+        PlpProgramMetaData metaData = new PlpProgramMetaData("testProgram");
+        Assertions.assertEquals(0, metaData.getProgramFiles().size());
+        metaData.addFileToProgram("testFile.asm");
+        Assertions.assertEquals(1, metaData.getProgramFiles().size());
+        Assertions.assertEquals("testFile.asm", metaData.getProgramFiles().get(0));
+        metaData.addFileToProgram("testFile2.asm");
+        Assertions.assertEquals(2, metaData.getProgramFiles().size());
+        Assertions.assertEquals("testFile2.asm", metaData.getProgramFiles().get(1));
+
+    }
+
+    @Test
+    public void testPlpProgramMetaDataDeleteFiles() {
+        Assertions.assertEquals(0, metaData.getProgramFiles().size());
+        metaData.addFileToProgram("testFile.asm");
+        Assertions.assertEquals(1, metaData.getProgramFiles().size());
+        metaData.deleteFileInProgram("testFile.asm");
+        Assertions.assertEquals(0, metaData.getProgramFiles().size());
+    }
+
+    @Test
+    public void testPlpProgramMetaDataAddFileAtIndex() {
+        Assertions.assertEquals(0, metaData.getProgramFiles().size());
+        metaData.addFileToProgramAtIndex("testFile.asm", 0);
+        Assertions.assertEquals(1, metaData.getProgramFiles().size());
+        metaData.addFileToProgramAtIndex("testFile2.asm", 0);
+        Assertions.assertEquals(2, metaData.getProgramFiles().size());
+        metaData.addFileToProgramAtIndex("testFile3.asm", 1);
+        Assertions.assertEquals(3, metaData.getProgramFiles().size());
+        metaData.addFileToProgramAtIndex("testFile4.asm", 10);
+        Assertions.assertEquals(4, metaData.getProgramFiles().size());
+        Assertions.assertEquals("testFile2.asm", metaData.getProgramFiles().get(0));
+        Assertions.assertEquals("testFile3.asm", metaData.getProgramFiles().get(1));
+        Assertions.assertEquals("testFile.asm", metaData.getProgramFiles().get(2));
+        Assertions.assertEquals("testFile4.asm", metaData.getProgramFiles().get(3));
+
+    }
+
+    @Test
+    public void testInitiatePlpProgramDataWithListOfFiles() {
+        List<String> files = Arrays.asList("main.asm", "abc.asm");
+        PlpProgramMetaData tempMetaData = new PlpProgramMetaData("testFile", files);
+
+        Assertions.assertEquals("testFile", tempMetaData.getProgramName());
+        List<String> actualFiles = tempMetaData.getProgramFiles();
+        Assertions.assertEquals(2, actualFiles.size());
+
+        Assertions.assertEquals("main.asm", actualFiles.get(0));
+        Assertions.assertEquals("abc.asm", actualFiles.get(1));
+    }
+
+}

--- a/src/test/java/org/plp/implementations/plpisa/PlpProgramTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpProgramTest.java
@@ -1,264 +1,230 @@
 package org.plp.implementations.plpisa;
 
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.plp.isa.AsmFile;
 
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PlpProgramTest {
 
-    FileSystem testOSXFileSystem;
-    FileSystem testUnixFileSystem;
-    FileSystem testWinFileSystem;
-
-    @BeforeEach
-    void initializeFileSystem() {
-        testOSXFileSystem = Jimfs.newFileSystem(Configuration.osX());
-        testUnixFileSystem = Jimfs.newFileSystem(Configuration.unix());
-        testWinFileSystem = Jimfs.newFileSystem(Configuration.windows());
-    }
-
     @Test
-    void createPlpProgramSuccessFulTest() {
-        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
-        Assertions.assertFalse(Files.exists(programOSXDirectory));
-        Assertions.assertDoesNotThrow(() -> {
-            PlpProgram program = new PlpProgram(programOSXDirectory);
-        });
-        Assertions.assertTrue(Files.exists(programOSXDirectory));
-
-        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
-        Assertions.assertFalse(Files.exists(programUnixDirectory));
-        Assertions.assertDoesNotThrow(() -> new PlpProgram(programUnixDirectory));
-        Assertions.assertTrue(Files.exists(programUnixDirectory));
-
-        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
-        Assertions.assertFalse(Files.exists(programWinDirectory));
-        Assertions.assertDoesNotThrow(() -> new PlpProgram(programWinDirectory));
-        Assertions.assertTrue(Files.exists(programWinDirectory));
-
-    }
-
-    @Test
-    void createPlpProgramFailureFileExistsTest() throws IOException{
-        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
-        Files.createFile(programOSXDirectory);
-        Assertions.assertTrue(Files.exists(programOSXDirectory));
-        Assertions.assertThrows(IOException.class, () -> {
-            PlpProgram program = new PlpProgram(programOSXDirectory);
-        });
-        Assertions.assertFalse(Files.isDirectory(programOSXDirectory));
-
-        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
-        Files.createFile(programUnixDirectory);
-        Assertions.assertTrue(Files.exists(programUnixDirectory));
-        Assertions.assertThrows(IOException.class, () -> new PlpProgram(programUnixDirectory));
-        Assertions.assertFalse(Files.isDirectory(programUnixDirectory));
-
-        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
-        Files.createFile(programWinDirectory);
-        Assertions.assertTrue(Files.exists(programWinDirectory));
-        Assertions.assertThrows(IOException.class, () -> new PlpProgram(programWinDirectory));
-        Assertions.assertFalse(Files.isDirectory(programWinDirectory));
-
-    }
-
-    @Test
-    void getPlpProgramDirectoryTest() {
-        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
-        Assertions.assertDoesNotThrow(() -> {
-            PlpProgram program = new PlpProgram(programOSXDirectory);
-            Assertions.assertEquals(program.getProgramDirectory(), programOSXDirectory.toString());
-        });
-
-        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
-        Assertions.assertDoesNotThrow(() -> {
-            PlpProgram program = new PlpProgram(programUnixDirectory);
-            Assertions.assertEquals(program.getProgramDirectory(), programUnixDirectory.toString());
-        });
-
-        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
-        Assertions.assertDoesNotThrow(() -> {
-            PlpProgram program = new PlpProgram(programWinDirectory);
-            Assertions.assertEquals(program.getProgramDirectory(), programWinDirectory.toString());
-        });
-
-    }
-
-    @Test
-    void loadExistingPlpFilesInDirectoryTest() throws Exception {
-        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
-        Files.createDirectory(programOSXDirectory);
-        Path testOSXFile1 = testOSXFileSystem.getPath(Paths.get(programOSXDirectory.toString(),"test1.asm").toString());
-        Files.createFile(testOSXFile1);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 1"));
-        Path testOSXFile2 = testOSXFileSystem.getPath(Paths.get(programOSXDirectory.toString(),"test2.asm").toString());
-        Files.createFile(testOSXFile2);
-        Files.write(testOSXFile2, Collections.singletonList("#This is Program 2"));
-        Path testOSXFile3 = testOSXFileSystem.getPath(Paths.get(programOSXDirectory.toString(),"test3.asm").toString());
-        Files.createFile(testOSXFile3);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 3"));
-
-        PlpProgram plpOsXProgram = new PlpProgram(programOSXDirectory);
-        Assertions.assertNotNull(plpOsXProgram.getAsmFile("test1.asm"));
-        Assertions.assertNotNull(plpOsXProgram.getAsmFile("test2.asm"));
-        Assertions.assertNotNull(plpOsXProgram.getAsmFile("test3.asm"));
-
-        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
-        Files.createDirectory(programUnixDirectory);
-        Path testUnixFile1 = testUnixFileSystem.getPath(Paths.get(programUnixDirectory.toString(),"test1.asm").toString());
-        Files.createFile(testUnixFile1);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 1"));
-        Path testUnixFile2 = testUnixFileSystem.getPath(Paths.get(programUnixDirectory.toString(),"test2.asm").toString());
-        Files.createFile(testUnixFile2);
-        Files.write(testOSXFile2, Collections.singletonList("#This is Program 2"));
-        Path testUnixFile3 = testUnixFileSystem.getPath(Paths.get(programUnixDirectory.toString(),"test3.asm").toString());
-        Files.createFile(testUnixFile3);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 3"));
-
-        PlpProgram plpUnixProgram = new PlpProgram(programUnixDirectory);
-        Assertions.assertNotNull(plpUnixProgram.getAsmFile("test1.asm"));
-        Assertions.assertNotNull(plpUnixProgram.getAsmFile("test2.asm"));
-        Assertions.assertNotNull(plpUnixProgram.getAsmFile("test3.asm"));
-
-        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
-        Files.createDirectory(programWinDirectory);
-        Path testWinFile1 = testWinFileSystem.getPath(Paths.get(programWinDirectory.toString(),"test1.asm").toString());
-        Files.createFile(testWinFile1);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 1"));
-        Path testWinFile2 = testWinFileSystem.getPath(Paths.get(programWinDirectory.toString(),"test2.asm").toString());
-        Files.createFile(testWinFile2);
-        Files.write(testOSXFile2, Collections.singletonList("#This is Program 2"));
-        Path testWinFile3 = testWinFileSystem.getPath(Paths.get(programWinDirectory.toString(),"test3.asm").toString());
-        Files.createFile(testWinFile3);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 3"));
-
-        PlpProgram plpWinProgram = new PlpProgram(programWinDirectory);
-        Assertions.assertNotNull(plpWinProgram.getAsmFile("test1.asm"));
-        Assertions.assertNotNull(plpWinProgram.getAsmFile("test2.asm"));
-        Assertions.assertNotNull(plpWinProgram.getAsmFile("test3.asm"));
-    }
-
-    @Test
-    void createNewAsmFileTest() throws Exception {
-        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
-        PlpProgram plpOsXProgram = new PlpProgram(programOSXDirectory);
-        AsmFile plpOsXFile = plpOsXProgram.createAsmFileInProgram("test1.asm");
-        Assertions.assertNotNull(plpOsXFile);
-        Assertions.assertEquals("test1.asm", plpOsXFile.getFileName());
-        Assertions.assertEquals(plpOsXFile, plpOsXProgram.getAsmFile("test1.asm"));
-
-        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
-        PlpProgram plpUnixProgram = new PlpProgram(programUnixDirectory);
-        AsmFile plpUnixFile = plpUnixProgram.createAsmFileInProgram("test1.asm");
-        Assertions.assertNotNull(plpUnixFile);
-        Assertions.assertEquals("test1.asm", plpUnixFile.getFileName());
-        Assertions.assertEquals(plpUnixFile, plpUnixProgram.getAsmFile("test1.asm"));
-
-        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
-        PlpProgram plpWinProgram = new PlpProgram(programWinDirectory);
-        AsmFile plpWinFile = plpWinProgram.createAsmFileInProgram("test1.asm");
-        Assertions.assertNotNull(plpWinFile);
-        Assertions.assertEquals("test1.asm", plpWinFile.getFileName());
-        Assertions.assertEquals(plpWinFile, plpWinProgram.getAsmFile("test1.asm"));
-
-    }
-
-    @Test
-    void createNewAsmFileFailureTest() throws Exception {
-        Path programOSXDirectory = testOSXFileSystem.getPath("rootFolder");
-        Files.createDirectory(programOSXDirectory);
-        Path testOSXFile1 = testOSXFileSystem.getPath(Paths.get(programOSXDirectory.toString(),"test1.asm").toString());
-        Files.createFile(testOSXFile1);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 1"));
-        PlpProgram plpOsXProgram = new PlpProgram(programOSXDirectory);
-        Assertions.assertThrows(IOException.class, () -> plpOsXProgram.createAsmFileInProgram("test1.asm"));
-
-        Path programUnixDirectory = testUnixFileSystem.getPath("rootFolder");
-        Files.createDirectory(programUnixDirectory);
-        Path testUnixFile1 = testUnixFileSystem.getPath(Paths.get(programUnixDirectory.toString(),"test1.asm").toString());
-        Files.createFile(testUnixFile1);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 1"));
-        PlpProgram plpUnixProgram = new PlpProgram(programUnixDirectory);
-        Assertions.assertThrows(IOException.class, () -> plpUnixProgram.createAsmFileInProgram("test1.asm"));
-
-        Path programWinDirectory = testWinFileSystem.getPath("rootFolder");
-        Files.createDirectory(programWinDirectory);
-        Path testWinFile1 = testWinFileSystem.getPath(Paths.get(programWinDirectory.toString(),"test1.asm").toString());
-        Files.createFile(testWinFile1);
-        Files.write(testOSXFile1, Collections.singletonList("#This is Program 1"));
-        PlpProgram plpWinProgram = new PlpProgram(programWinDirectory);
-        Assertions.assertThrows(IOException.class, () -> plpWinProgram.createAsmFileInProgram("test1.asm"));
-
-    }
-
-    @Test
-    void addFilesToProgramFailureTest(@TempDir Path rootDirectory) throws Exception {
-        Path programDirectory = rootDirectory.resolve("testProgram");
+    void createPlpProgramSuccessFulTest(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
         Files.createDirectory(programDirectory);
-        Path asmFile1 = programDirectory.resolve("test1.asm");
-        Files.write(asmFile1, Arrays.asList("# This is program 1"));
-        Path asmFile2 = programDirectory.resolve("test2.asm");
-        Files.write(asmFile2, Arrays.asList("# This is program 2"));
 
-        Path asmFile3 = rootDirectory.resolve("test2.asm");
-        Files.write(asmFile3, Arrays.asList("# This is another program"));
-        PlpFile plpFile = new PlpFile(asmFile3);
+        PlpProgram program = new PlpProgram("testProgram", programDirectory);
 
-        PlpProgram plpProgram = new PlpProgram(programDirectory);
-        Assertions.assertThrows(IOException.class,
-                () -> plpProgram.copyAsmFileToProgram(plpFile),
-                "File with same name test2.asm exists in the program testProgram");
+        Assertions.assertEquals("testProgram.plp", program.getProgramName());
+        Assertions.assertEquals(
+                Paths.get(programDirectory.toString(), "testProgram.plp"),
+                program.getProgramLocation());
 
-        AsmFile existingFile = plpProgram.getAsmFile("test2.asm");
-        Assertions.assertNotNull(existingFile);
-        Assertions.assertEquals(existingFile.getInstructionAtLine(1), "# This is program 2");
-    }
-
-    @Test
-    void addFilesToProgramSuccessTest(@TempDir Path rootDirectory) throws Exception {
-        Path programDirectory = rootDirectory.resolve("testProgram");
-        Files.createDirectory(programDirectory);
-        Path asmFile1 = programDirectory.resolve("test1.asm");
-        Files.write(asmFile1, Arrays.asList("# This is program 1"));
-
-        Path asmFile2 = rootDirectory.resolve("test2.asm");
-        Files.write(asmFile2, Arrays.asList("# This is program 2"));
-        PlpFile plpFile = new PlpFile(asmFile2);
-
-        PlpProgram plpProgram = new PlpProgram(programDirectory);
-        Assertions.assertDoesNotThrow(() -> plpProgram.copyAsmFileToProgram(plpFile));
-
-        Assertions.assertNotNull(plpProgram.getAsmFile("test2.asm"));
+        Assertions.assertEquals(1, program.getAsmFilesOfProgram().size());
+        Assertions.assertEquals("main.asm", program.getAsmFilesOfProgram().get(0).getFileName());
+        Assertions.assertEquals(program, program.getAsmFilesOfProgram().get(0).getAsmProgramOfFile());
 
     }
 
     @Test
-    void getAsmFilesInProgramTest(@TempDir Path rootDirectory) throws Exception {
-        Path programDirectory = rootDirectory.resolve("testProgram");
+    void createPlpProgramSuccessWithExtensionTest(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
         Files.createDirectory(programDirectory);
-        Path asmFile1 = programDirectory.resolve("test1.asm");
-        Files.write(asmFile1, Arrays.asList("# This is program 1"));
-        Path asmFile2 = programDirectory.resolve("test2.asm");
-        Files.write(asmFile2, Arrays.asList("# This is program 2"));
 
-        PlpProgram plpProgram = new PlpProgram(programDirectory);
-        List<AsmFile> asmFiles = plpProgram.getAsmFilesOfProgram();
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertEquals("testProgram.plp", program.getProgramName());
+        Assertions.assertEquals(
+                Paths.get(programDirectory.toString(), "testProgram.plp"),
+                program.getProgramLocation());
+    }
+
+    @Test
+    void loadExistingProgramTest(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+        AsmFile asmFile = program.getAsmFile("main.asm");
+        asmFile.appendInstructionsToFile(Arrays.asList("#This is starting", ".org 0x1000000", "addu $t1, $t2, $t3"));
+
+        PlpProgram readProgram = new PlpProgram("testProgram.plp", programDirectory);
+        Assertions.assertEquals(program.getProgramName(), readProgram.getProgramName());
+        Assertions.assertEquals(program.getProgramLocation().toString(), readProgram.getProgramLocation().toString());
+        Assertions.assertEquals(1, readProgram.getAsmFilesOfProgram().size());
+        AsmFile readAsmFile = readProgram.getAsmFile("main.asm");
+        Assertions.assertEquals(readProgram, readAsmFile.getAsmProgramOfFile());
+        Assertions.assertEquals(asmFile.getFileName(), readAsmFile.getFileName());
+        List<String> instructionsRead = readAsmFile.getInstructionsOfFile();
+        Assertions.assertEquals(3, instructionsRead.size());
+        Assertions.assertEquals("#This is starting", instructionsRead.get(0));
+        Assertions.assertEquals(".org 0x1000000", instructionsRead.get(1));
+        Assertions.assertEquals("addu $t1, $t2, $t3", instructionsRead.get(2));
+    }
+
+    @Test
+    public void testGetAsmFilesOfProgram(@TempDir Path rootDirectory) throws IOException{
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+        AsmFile asmFile = program.getAsmFile("main.asm");
+        asmFile.appendInstructionsToFile(Arrays.asList("#This is starting", ".org 0x1000000", "addu $t1, $t2, $t3"));
+
+        AsmFile readAsmFile = program.getAsmFile("main.asm");
+        Assertions.assertEquals(1, program.getAsmFilesOfProgram().size());
+        Assertions.assertEquals("main.asm", program.getAsmFilesOfProgram().get(0).getFileName());
+    }
+
+    @Test
+    public void testGetAsmFile(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+        AsmFile asmFile = program.getAsmFile("main.asm");
+        Assertions.assertEquals("main.asm", asmFile.getFileName());
+    }
+
+    @Test
+    public void testCreateAsmFileInProgram(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        program.createAsmFileInProgram("newFile.asm");
+
+        List<AsmFile> asmFiles = program.getAsmFilesOfProgram();
 
         Assertions.assertEquals(2, asmFiles.size());
-        Assertions.assertTrue(asmFiles.stream().anyMatch(x -> x.getFileName().equals("test1.asm")));
-        Assertions.assertTrue(asmFiles.stream().anyMatch(x -> x.getFileName().equals("test2.asm")));
-        Assertions.assertTrue(asmFiles.stream().anyMatch(x -> x.getInstructionAtLine(1).equals("# This is program 1")));
-        Assertions.assertTrue(asmFiles.stream().anyMatch(x -> x.getInstructionAtLine(1).equals("# This is program 2")));
+
+        List<String> asmFileNames = asmFiles.stream().map(AsmFile::getFileName).collect(Collectors.toList());
+
+        Assertions.assertTrue(asmFileNames.contains("main.asm"));
+        Assertions.assertTrue(asmFileNames.contains("newFile.asm"));
+
     }
+
+    @Test
+    public void testCreateAsmFileFailure(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertThrows(IOException.class, () -> {
+            program.createAsmFileInProgram("main.asm");
+        }, "testProgram.plp program already has a file with same name as main.asm");
+    }
+
+    @Test
+    public void testDeleteAsmFileInProgram(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        program.createAsmFileInProgram("newFile.asm");
+
+        Assertions.assertEquals(2, program.getAsmFilesOfProgram().size());
+
+        program.deleteAsmFileInProgram("newFile.asm");
+
+        Assertions.assertEquals(1, program.getAsmFilesOfProgram().size());
+
+        Assertions.assertEquals("main.asm", program.getAsmFilesOfProgram().get(0).getFileName());
+
+    }
+
+    @Test
+    public void testDeleteAsmFileFailure(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertThrows(IOException.class, () -> {
+            program.deleteAsmFileInProgram("newFile.asm");
+        }, "testProgram.plp program do not have file newFile.asm");
+    }
+
+    @Test
+    public void testRenameAsmFileSuccess(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertEquals(1, program.getAsmFilesOfProgram().size());
+
+        Assertions.assertEquals("main.asm", program.getAsmFile("main.asm").getFileName());
+
+        program.renameAsmFileInProgram("main.asm", "newName.asm");
+
+        Assertions.assertEquals(1, program.getAsmFilesOfProgram().size());
+
+        Assertions.assertEquals("newName.asm", program.getAsmFile("newName.asm").getFileName());
+
+    }
+
+    @Test
+    public void testRenameAsmFileFailureFileDoNotExists(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertEquals(1, program.getAsmFilesOfProgram().size());
+
+        Assertions.assertEquals("main.asm", program.getAsmFile("main.asm").getFileName());
+
+        Assertions.assertThrows(IOException.class,
+                () -> {program.renameAsmFileInProgram("newName.asm", "nextName.asm");},
+                "testProgram.plp program does not have file newName.asm");
+    }
+
+    @Test
+    public void testRenameAsmFileFailureFileAlreadyExists(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        program.createAsmFileInProgram("newName.asm");
+
+        Assertions.assertThrows(IOException.class,
+                () -> {program.renameAsmFileInProgram("main.asm", "newName.asm");},
+                "testProgram.plp program already has a file with same name - newName.asm");
+
+    }
+
+    @Test
+    public void testProgramName(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertEquals("testProgram.plp", program.getProgramName());
+    }
+
+    @Test
+    public void testProgramLocation(@TempDir Path rootDirectory) throws IOException {
+        Path programDirectory = rootDirectory.resolve("TestProgramDirectory");
+        Files.createDirectory(programDirectory);
+
+        PlpProgram program = new PlpProgram("testProgram.plp", programDirectory);
+
+        Assertions.assertEquals(programDirectory.toString() + "/testProgram.plp", program.getProgramLocation().toString());
+    }
+
 
 }

--- a/src/test/java/org/plp/implementations/plpisa/PlpTokenTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpTokenTest.java
@@ -1,0 +1,37 @@
+package org.plp.implementations.plpisa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PlpTokenTest {
+
+    @Test
+    public void getTokenTypeOfTokenTest() {
+        PlpToken plpToken = new PlpToken(PlpTokenType.DIRECTIVE, ".org");
+        Assertions.assertEquals(PlpTokenType.DIRECTIVE, plpToken.getTokenType());
+    }
+
+    @Test
+    public void getActualValueOfToken() {
+        PlpToken plpToken = new PlpToken(PlpTokenType.NUMERIC, "0x100000");
+        Assertions.assertEquals("0x100000", plpToken.getValue());
+    }
+
+    @Test
+    public void initiateTokenWithNullTokenTypeTest() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            new PlpToken(null, "randomValue");
+        });
+
+    }
+
+    @Test
+    public void initiateTokenWithNullValueTest() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            new PlpToken(PlpTokenType.NUMERIC, null);
+        });
+
+    }
+}

--- a/src/test/java/org/plp/implementations/plpisa/PlpTokenTypeTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpTokenTypeTest.java
@@ -20,7 +20,7 @@ public class PlpTokenTypeTest {
         String invalidLabel4 = "asdf asdfs:";
         String invalidLabel5 = "asdf_asf";
 
-        Pattern labelDefPattern = Pattern.compile(PlpTokenType.LABEL_DEFINITION.regex());
+        Pattern labelDefPattern = Pattern.compile(PlpTokenType.LABELDEFINITION.regex());
         Assertions.assertTrue(labelDefPattern.matcher(validLabel1).matches());
         Assertions.assertTrue(labelDefPattern.matcher(validLabel2).matches());
         Assertions.assertTrue(labelDefPattern.matcher(validLabel3).matches());
@@ -72,6 +72,43 @@ public class PlpTokenTypeTest {
     }
 
     @Test
+    public void testPseudoInstructionToken() {
+        Pattern instructionPattern = Pattern.compile(PlpTokenType.PSEUDOINSTRUCTION.regex());
+
+        String validInstruction1 = "b";
+        String validInstruction2 = "MOVE";
+        String validInstruction3 = "Pop";
+        String validInstruction4 = "push";
+        String validInstruction5 = "li";
+
+        String invalidInstruction1 = ".org";
+        String invalidInstruction2 = "$t1";
+        String invalidInstruction3 = "0x40";
+        String invalidInstruction4 = "test_main:";
+        String invalidInstruction5 = "($t2)";
+        String invalidInstruction6 = "asdf asdf";
+        String invalidInstruction7 = "addu";
+        String invalidInstruction8 = "as-asdf";
+        String invalidInstruction9 = "as89";
+
+        Assertions.assertTrue(instructionPattern.matcher(validInstruction1).matches());
+        Assertions.assertTrue(instructionPattern.matcher(validInstruction2).matches());
+        Assertions.assertTrue(instructionPattern.matcher(validInstruction3).matches());
+        Assertions.assertTrue(instructionPattern.matcher(validInstruction4).matches());
+        Assertions.assertTrue(instructionPattern.matcher(validInstruction5).matches());
+
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction1).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction2).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction3).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction4).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction5).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction6).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction7).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction8).matches());
+        Assertions.assertFalse(instructionPattern.matcher(invalidInstruction9).matches());
+    }
+
+    @Test
     public void testLabelUsageToken() {
         String validLabel1 = "main";
         String validLabel2 = "test_label";
@@ -84,7 +121,7 @@ public class PlpTokenTypeTest {
         String invalidLabel4 = "asdf asdfs";
         String invalidLabel6 = "main:";
 
-        Pattern labelUsagePattern = Pattern.compile(PlpTokenType.LABEL_USAGE.regex());
+        Pattern labelUsagePattern = Pattern.compile(PlpTokenType.LABELUSAGE.regex());
         Assertions.assertTrue(labelUsagePattern.matcher(validLabel1).matches());
         Assertions.assertTrue(labelUsagePattern.matcher(validLabel2).matches());
         Assertions.assertTrue(labelUsagePattern.matcher(validLabel3).matches());
@@ -105,8 +142,8 @@ public class PlpTokenTypeTest {
         String validRegister2 = "$zero";
         String validRegister3 = "$0";
         String validRegister4 = "$ir";
+        String validRegister5 = "$1";
 
-        String invalidRegister1 = "$1";
         String invalidRegister2 = "t1";
         String invalidRegister3 = "abc";
         String invalidRegister4 = ".org";
@@ -116,8 +153,8 @@ public class PlpTokenTypeTest {
         Assertions.assertTrue(registerPattern.matcher(validRegister2).matches());
         Assertions.assertTrue(registerPattern.matcher(validRegister3).matches());
         Assertions.assertTrue(registerPattern.matcher(validRegister4).matches());
+        Assertions.assertTrue(registerPattern.matcher(validRegister5).matches());
 
-        Assertions.assertFalse(registerPattern.matcher(invalidRegister1).matches());
         Assertions.assertFalse(registerPattern.matcher(invalidRegister2).matches());
         Assertions.assertFalse(registerPattern.matcher(invalidRegister3).matches());
         Assertions.assertFalse(registerPattern.matcher(invalidRegister4).matches());
@@ -162,7 +199,7 @@ public class PlpTokenTypeTest {
 
     @Test
     public void testParenthesisRegisterToken() {
-        Pattern parenthesisRegisterPattern = Pattern.compile(PlpTokenType.PARENTHESIS_REGISTER.regex());
+        Pattern parenthesisRegisterPattern = Pattern.compile(PlpTokenType.PARENTHESISREGISTER.regex());
 
         String validParenthesisRegister1 = "($zero)";
         String validParenthesisRegister2 = "($t1)";
@@ -311,7 +348,7 @@ public class PlpTokenTypeTest {
 
     @Test
     public void testNewlineToken() {
-        Pattern newlinePattern = Pattern.compile(PlpTokenType.NEW_LINE.regex());
+        Pattern newlinePattern = Pattern.compile(PlpTokenType.NEWLINE.regex());
 
         String validNewLineToken1 = "\n";
         String validNewLineToken2 = "\t\t";

--- a/src/test/java/org/plp/implementations/plpisa/PlpTokenTypeTest.java
+++ b/src/test/java/org/plp/implementations/plpisa/PlpTokenTypeTest.java
@@ -346,27 +346,4 @@ public class PlpTokenTypeTest {
         Assertions.assertFalse(numericPattern.matcher(invalidNumber7).matches());
     }
 
-    @Test
-    public void testNewlineToken() {
-        Pattern newlinePattern = Pattern.compile(PlpTokenType.NEWLINE.regex());
-
-        String validNewLineToken1 = "\n";
-        String validNewLineToken2 = "\t\t";
-        String validNewLineToken3 = "\r\f";
-        String validNewLineToken4 = "\n\n\t\t\t\r\f";
-        String validNewLineToken5 = "  ";
-
-        String invalidNewLineToken1 = "asdf\t\tasf\n";
-        String invalidNewLineToken2 = "a\n";
-
-        Assertions.assertTrue(newlinePattern.matcher(validNewLineToken1).matches());
-        Assertions.assertTrue(newlinePattern.matcher(validNewLineToken2).matches());
-        Assertions.assertTrue(newlinePattern.matcher(validNewLineToken3).matches());
-        Assertions.assertTrue(newlinePattern.matcher(validNewLineToken4).matches());
-        Assertions.assertTrue(newlinePattern.matcher(validNewLineToken5).matches());
-
-        Assertions.assertFalse(newlinePattern.matcher(invalidNewLineToken1).matches());
-        Assertions.assertFalse(newlinePattern.matcher(invalidNewLineToken2).matches());
-    }
-
 }


### PR DESCRIPTION
This change will do the lexer operation on the given input. Idea is, for each line in the PlpProgram or PlpFile, we will be invoking the `lex` function on it. `lex` will provide list of tokens. 
Based on these token assembler will be able to preprocess it before doing the final assembling.

As I implemented this, I realized that our Instruction Token cannot be generic, rather it has to be very specific. So it will have a list of instructions PLP will support. I have introduced one more token called Pseudo Instruction which will have our pseudo instructions.

As we will be lexing each line, I do not think we no longer need Newline token. So removed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/progressive-learning-platform/plpassembler/38)
<!-- Reviewable:end -->
